### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -3,7 +3,7 @@ name: deno
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -3,7 +3,7 @@ name: node
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Renames the `master` branch to `main` to align with the [Software Freedom Conservancy recommendation](https://sfconservancy.org/news/2020/jun/23/gitbranchname/).