### PR TITLE
Remove `XMLHttpRequest` as fallback to Fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,6 @@ i18next.use(i18nextHttpBackend).init(i18nextOptions);
   // if value returned it will send a POST request
   parseLoadPayload: function(languages, namespaces) { return undefined },
 
-  // allow cross domain requests
-  crossDomain: false,
-
-  // allow credentials on cross domain requests
-  withCredentials: false,
-
-  // overrideMimeType sets request.overrideMimeType("application/json")
-  overrideMimeType: false,
-
   // custom request headers sets request.setRequestHeader(key, value)
   customHeaders: {
     authorization: 'foo',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,14 +63,6 @@ export interface HttpBackendOptions {
     namespaces: string[]
   ): { [key: string]: any } | undefined;
   /**
-   * allow cross domain requests
-   */
-  crossDomain?: boolean;
-  /**
-   * allow credentials on cross domain requests
-   */
-  withCredentials?: boolean;
-  /**
    * define a custom xhr function
    * can be used to support XDomainRequest in IE 8 and 9
    */

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,6 @@ const getDefaults = () => {
     reloadInterval: typeof window !== 'undefined' ? false : 60 * 60 * 1000,
     customHeaders: {},
     queryStringParams: {},
-    crossDomain: false, // used for XmlHttpRequest
-    withCredentials: false, // used for XmlHttpRequest
-    overrideMimeType: false, // used for XmlHttpRequest
     requestOptions: { // used for fetch
       mode: 'cors',
       credentials: 'same-origin',

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,40 +1,3 @@
-import { hasXMLHttpRequest } from './utils.js'
-
-let fetchApi = typeof fetch === 'function' ? fetch : undefined
-if (typeof global !== 'undefined' && global.fetch) {
-  fetchApi = global.fetch
-} else if (typeof window !== 'undefined' && window.fetch) {
-  fetchApi = window.fetch
-}
-let XmlHttpRequestApi
-if (hasXMLHttpRequest()) {
-  if (typeof global !== 'undefined' && global.XMLHttpRequest) {
-    XmlHttpRequestApi = global.XMLHttpRequest
-  } else if (typeof window !== 'undefined' && window.XMLHttpRequest) {
-    XmlHttpRequestApi = window.XMLHttpRequest
-  }
-}
-let ActiveXObjectApi
-if (typeof ActiveXObject === 'function') {
-  if (typeof global !== 'undefined' && global.ActiveXObject) {
-    ActiveXObjectApi = global.ActiveXObject
-  } else if (typeof window !== 'undefined' && window.ActiveXObject) {
-    ActiveXObjectApi = window.ActiveXObject
-  }
-}
-
-if (typeof fetchApi !== 'function') fetchApi = undefined
-
-if (!fetchApi && !XmlHttpRequestApi && !ActiveXObjectApi) {
-  try {
-    // top-level await is not available on everywhere
-    // fetchApi = (await import('cross-fetch')).default
-    import('cross-fetch').then((mod) => {
-      fetchApi = mod.default
-    }).catch(() => {})
-  } catch (e) {}
-}
-
 const addQueryString = (url, params) => {
   if (params && typeof params === 'object') {
     let queryString = ''
@@ -64,11 +27,8 @@ const fetchIt = (url, fetchOptions, callback, altFetch) => {
     }
     // fall through
   }
-  if (typeof fetch === 'function') { // react-native debug mode needs the fetch function to be called directly (no alias)
-    fetch(url, fetchOptions).then(resolver).catch(callback)
-  } else {
-    fetchApi(url, fetchOptions).then(resolver).catch(callback)
-  }
+
+  fetch(url, fetchOptions).then(resolver).catch(callback)
 }
 
 let omitFetchOptions = false
@@ -111,47 +71,6 @@ const requestWithFetch = (options, url, payload, callback) => {
   }
 }
 
-// xml http request stuff
-const requestWithXmlHttpRequest = (options, url, payload, callback) => {
-  if (payload && typeof payload === 'object') {
-    // if (!cache) payload._t = Date.now()
-    // URL encoded form payload must be in querystring format
-    payload = addQueryString('', payload).slice(1)
-  }
-
-  if (options.queryStringParams) {
-    url = addQueryString(url, options.queryStringParams)
-  }
-
-  try {
-    const x = XmlHttpRequestApi ? new XmlHttpRequestApi() : new ActiveXObjectApi('MSXML2.XMLHTTP.3.0')
-    x.open(payload ? 'POST' : 'GET', url, 1)
-    if (!options.crossDomain) {
-      x.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
-    }
-    x.withCredentials = !!options.withCredentials
-    if (payload) {
-      x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded')
-    }
-    if (x.overrideMimeType) {
-      x.overrideMimeType('application/json')
-    }
-    let h = options.customHeaders
-    h = typeof h === 'function' ? h() : h
-    if (h) {
-      for (const i in h) {
-        x.setRequestHeader(i, h[i])
-      }
-    }
-    x.onreadystatechange = () => {
-      x.readyState > 3 && callback(x.status >= 400 ? x.statusText : null, { status: x.status, data: x.responseText })
-    }
-    x.send(payload)
-  } catch (e) {
-    console && console.log(e)
-  }
-}
-
 const request = (options, url, payload, callback) => {
   if (typeof payload === 'function') {
     callback = payload
@@ -159,17 +78,7 @@ const request = (options, url, payload, callback) => {
   }
   callback = callback || (() => {})
 
-  if (fetchApi && url.indexOf('file:') !== 0) {
-    // use fetch api
-    return requestWithFetch(options, url, payload, callback)
-  }
-
-  if (hasXMLHttpRequest() || typeof ActiveXObject === 'function') {
-    // use xml http request
-    return requestWithXmlHttpRequest(options, url, payload, callback)
-  }
-
-  callback(new Error('No fetch and no xhr implementation found!'))
+  return requestWithFetch(options, url, payload, callback)
 }
 
 export default request

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,10 +13,6 @@ export function defaults (obj) {
   return obj
 }
 
-export function hasXMLHttpRequest () {
-  return (typeof XMLHttpRequest === 'function' || typeof XMLHttpRequest === 'object')
-}
-
 /**
  * Determine whether the given `maybePromise` is a Promise.
  *

--- a/package.json
+++ b/package.json
@@ -11,17 +11,13 @@
       "default": "./lib/index.js"
     }
   },
-  "dependencies": {
-    "cross-fetch": "4.1.0"
-  },
   "devDependencies": {
     "expect.js": "0.3.1",
     "i18next": "24.0.0",
     "json-server": "0.17.4",
     "json5": "2.2.3",
     "jsonc-parser": "3.3.1",
-    "mocha": "10.8.2",
-    "xmlhttprequest": "1.8.0"
+    "mocha": "10.8.2"
   },
   "description": "i18next-http-backend is a backend layer for i18next using in Node.js, in the browser and for Deno.",
   "keywords": [
@@ -39,9 +35,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "test:xmlhttpreq": "mocha test -R spec --require test/fixtures/xmlHttpRequest.cjs --experimental-modules",
-    "test:fetch": "mocha test -R spec --experimental-modules",
-    "test": "npm run test:fetch && npm run test:xmlhttpreq",
+    "test": "mocha test -R spec",
     "test:deno": "deno test --allow-net test/deno/*.js",
     "preversion": "npm run test && npm run build && git push",
     "postversion": "git push && git push --tags"

--- a/test/backendConnector.load.spec.js
+++ b/test/backendConnector.load.spec.js
@@ -5,7 +5,7 @@ import server from './fixtures/server.js'
 
 i18next.init()
 
-describe(`BackendConnector basic load using ${typeof XMLHttpRequest === 'function' ? 'XMLHttpRequest' : 'fetch'}`, () => {
+describe('BackendConnector basic load', () => {
   let connector
 
   before((done) => {

--- a/test/fixtures/xmlHttpRequest.cjs
+++ b/test/fixtures/xmlHttpRequest.cjs
@@ -1,3 +1,0 @@
-const XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest
-global.XMLHttpRequest = XMLHttpRequest
-global.fetch = undefined

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -4,11 +4,10 @@ import i18next from 'i18next'
 import JSON5 from 'json5'
 import { parse as parseJSONC } from 'jsonc-parser'
 import server from './fixtures/server.js'
-import { hasXMLHttpRequest } from '../lib/utils.js'
 
 i18next.init()
 
-describe(`http backend using ${hasXMLHttpRequest() ? 'XMLHttpRequest' : 'fetch'}`, () => {
+describe('http backend', () => {
   before(server)
 
   describe('#read', () => {
@@ -31,59 +30,35 @@ describe(`http backend using ${hasXMLHttpRequest() ? 'XMLHttpRequest' : 'fetch'}
         }
       )
     })
-    if (!hasXMLHttpRequest()) {
-      it('should load data', async () => {
-        let errO
-        let dataO
-        const done = await new Promise((resolve, reject) => {
-          backend.read('en', 'test', (err, data) => {
-            // dont check here with "except", if there is an error
-            // because the test will just "hang" with no further info
-            errO = err
-            dataO = data
-            resolve(true)
-          })
-          setTimeout(() => reject(new Error('timeout')), 1500).unref()
-        })
-        // evaluate outside callback to get actuall error when something is wrong
-        expect(errO).to.be(null)
-        expect(dataO).to.eql({ key: 'passing' })
-        expect(done).to.be(true)
-        expect(logs).to.have.length(1)
-        expect(logs[0]).to.have.length(2)
-        expect(logs[0][0]).to.eql('http://localhost:5001/locales/en/test')
-        expect(logs[0][1]).to.have.property('method', 'GET')
-        expect(logs[0][1]).to.have.property('headers')
-        expect(logs[0][1].headers).to.have.property('User-Agent')
-        expect(logs[0][1]).to.have.property('mode', 'cors')
-        expect(logs[0][1]).to.have.property('credentials', 'same-origin')
-        expect(logs[0][1]).to.have.property('cache', 'default')
-        expect(logs[0][1]).to.have.property('body')
-      })
-    }
 
-    if (hasXMLHttpRequest()) {
-      it('should load data', async () => {
-        let errO
-        let dataO
-        const done = await new Promise((resolve, reject) => {
-          backend.read('en', 'test', (err, data) => {
-            // dont check here with "except", if there is an error
-            // because the test will just "hang" with no further info
-            errO = err
-            dataO = data
-            resolve(true)
-          })
-          setTimeout(() => reject(new Error('timeout')), 1500).unref()
+    it('should load data', async () => {
+      let errO
+      let dataO
+      const done = await new Promise((resolve, reject) => {
+        backend.read('en', 'test', (err, data) => {
+          // dont check here with "except", if there is an error
+          // because the test will just "hang" with no further info
+          errO = err
+          dataO = data
+          resolve(true)
         })
-        // evaluate outside callback to get actuall error when something is wrong
-        expect(errO).to.be(null)
-        expect(dataO).to.eql({ key: 'passing' })
-        expect(done).to.be(true)
-        // fetch was not used
-        expect(logs).to.eql([])
+        setTimeout(() => reject(new Error('timeout')), 1500).unref()
       })
-    }
+      // evaluate outside callback to get actuall error when something is wrong
+      expect(errO).to.be(null)
+      expect(dataO).to.eql({ key: 'passing' })
+      expect(done).to.be(true)
+      expect(logs).to.have.length(1)
+      expect(logs[0]).to.have.length(2)
+      expect(logs[0][0]).to.eql('http://localhost:5001/locales/en/test')
+      expect(logs[0][1]).to.have.property('method', 'GET')
+      expect(logs[0][1]).to.have.property('headers')
+      expect(logs[0][1].headers).to.have.property('User-Agent')
+      expect(logs[0][1]).to.have.property('mode', 'cors')
+      expect(logs[0][1]).to.have.property('credentials', 'same-origin')
+      expect(logs[0][1]).to.have.property('cache', 'default')
+      expect(logs[0][1]).to.have.property('body')
+    })
 
     it('should throw error on not existing file', (done) => {
       backend.read('en', 'notexisting', (err, data) => {
@@ -288,46 +263,44 @@ describe(`http backend using ${hasXMLHttpRequest() ? 'XMLHttpRequest' : 'fetch'}
     })
   })
 
-  if (!hasXMLHttpRequest()) {
-    describe('with custom request options', () => {
-      let backend
+  describe('with custom request options', () => {
+    let backend
 
-      before(() => {
-        backend = new Http(
-          {
-            interpolator: i18next.services.interpolator
-          },
-          {
-            loadPath: 'http://localhost:5001/locales/{{lng}}/{{ns}}',
-            addPath: 'http://localhost:5001/create/{{lng}}/{{ns}}',
-            requestOptions: {
-              method: 'PATCH'
-            }
+    before(() => {
+      backend = new Http(
+        {
+          interpolator: i18next.services.interpolator
+        },
+        {
+          loadPath: 'http://localhost:5001/locales/{{lng}}/{{ns}}',
+          addPath: 'http://localhost:5001/create/{{lng}}/{{ns}}',
+          requestOptions: {
+            method: 'PATCH'
           }
-        )
-      })
+        }
+      )
+    })
 
-      describe('#read', () => {
-        it('should read data', (done) => {
-          backend.read('it', 'testns', function (err, data) {
-            expect(err).not.to.be.ok()
-            expect(data).to.eql({ via: 'patch' })
-            done()
-          })
-        })
-      })
-
-      describe('#create', () => {
-        it('should write data', (done) => {
-          backend.create('it', 'testns', 'new.key', 'new value', (dataArray, resArray) => {
-            expect(dataArray).to.eql([null])
-            expect(resArray).to.eql([ { status: 200, data: '' } ])
-            done()
-          })
+    describe('#read', () => {
+      it('should read data', (done) => {
+        backend.read('it', 'testns', function (err, data) {
+          expect(err).not.to.be.ok()
+          expect(data).to.eql({ via: 'patch' })
+          done()
         })
       })
     })
-  }
+
+    describe('#create', () => {
+      it('should write data', (done) => {
+        backend.create('it', 'testns', 'new.key', 'new value', (dataArray, resArray) => {
+          expect(dataArray).to.eql([null])
+          expect(resArray).to.eql([ { status: 200, data: '' } ])
+          done()
+        })
+      })
+    })
+  })
 
   describe('with loadPath function returning falsy', () => {
     let backend

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -1,9 +1,8 @@
 import expect from 'expect.js'
 import request from '../lib/request.js'
 import server from './fixtures/server.js'
-import { hasXMLHttpRequest } from '../lib/utils.js'
 
-describe(`request ${hasXMLHttpRequest() ? 'XMLHttpRequest' : 'fetch'}`, () => {
+describe('request', () => {
   before(server)
 
   describe('#missing', () => {


### PR DESCRIPTION
Removes the fallback to `XMLHttpRequest` as I'll only be targeting the Fetch API. This also removes the `cross-fetch` polyfill and options specific to `XMLHttpRequest`.